### PR TITLE
add empty value for docker registry mirror

### DIFF
--- a/roles/docker_debian/defaults/main.yaml
+++ b/roles/docker_debian/defaults/main.yaml
@@ -4,4 +4,4 @@ os: "{{ ansible_distribution | lower }}"
 docker_repository: "https://download.docker.com/linux/{{ os }}"
 docker_gpg_key: "https://download.docker.com/linux/{{ os }}/gpg"
 docker_package: "docker-ce"
-
+docker_registry_mirror: ""


### PR DESCRIPTION
Should fix the error I was hitting when using this role:
```
TASK [ethereum.quokkaops.docker_debian : Generate Docker Configuation] *********
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'docker_registry_mirror' is undefined
fatal: [excalidraw]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'docker_registry_mirror' is undefined"}
```
I see the template is defined this way:
```
{
  {% if docker_registry_mirror %}
  "registry-mirrors": ["{{ docker_registry_mirror }}"]
  {% endif %}
}
```
This check fails if the variable is undefined rather than treating it as falsy. Not sure if this default var would break other workflows, so do take a look, and if so we can modify the templating logic instead.