### PR TITLE
feat(teleport_agent): add configurable SSH enhanced session recording

### DIFF
--- a/roles/teleport_agent/README.md
+++ b/roles/teleport_agent/README.md
@@ -15,6 +15,9 @@ Default variables are defined in [defaults/main.yaml](defaults/main.yaml)
 |----------|-------------|---------|
 | `teleport_agent_apps` | List of applications to expose | `[]` |
 | `teleport_agent_desktops` | List of Windows desktops | `[]` |
+| `teleport_agent_enhanced_recording_enabled` | Enable SSH enhanced session recording (BPF). Requires a recent kernel; scope per-group rather than globally. | `false` |
+| `teleport_agent_enhanced_recording_command_buffer_size` | BPF command event buffer size, in pages | `8` |
+| `teleport_agent_enhanced_recording_network_buffer_size` | BPF network event buffer size, in pages | `8` |
 
 ## Dependencies
 

--- a/roles/teleport_agent/defaults/main.yaml
+++ b/roles/teleport_agent/defaults/main.yaml
@@ -1,3 +1,7 @@
 ---
 teleport_agent_apps: []
 teleport_agent_desktops: []
+# Enhanced session recording (BPF). Requires a recent kernel; scope per-group rather than globally.
+teleport_agent_enhanced_recording_enabled: false
+teleport_agent_enhanced_recording_command_buffer_size: 8
+teleport_agent_enhanced_recording_network_buffer_size: 8

--- a/roles/teleport_agent/templates/teleport-config.yml.j2
+++ b/roles/teleport_agent/templates/teleport-config.yml.j2
@@ -27,6 +27,12 @@ ssh_service:
   - name: hostname
     command: [hostname]
     period: 1m0s
+{% if teleport_agent_enhanced_recording_enabled %}
+  enhanced_recording:
+    enabled: true
+    command_buffer_size: {{ teleport_agent_enhanced_recording_command_buffer_size }}
+    network_buffer_size: {{ teleport_agent_enhanced_recording_network_buffer_size }}
+{% endif %}
 proxy_service:
   enabled: "no"
   https_keypairs: []


### PR DESCRIPTION
Adds optional BPF-based enhanced session recording to the ssh_service block, gated on `teleport_agent_enhanced_recording_enabled` (default false). Buffer sizes are tunable via
`teleport_agent_enhanced_recording_command_buffer_size` and `teleport_agent_enhanced_recording_network_buffer_size` (default 8 pages).

Default-off so existing agent-managed nodes are unaffected; consumers opt in per-group rather than fleet-wide, since BPF requires a recent kernel and adds runtime cost.