### PR TITLE
fix(docker_debian): remove conflicting distro packages before installing docker-ce

### DIFF
--- a/roles/docker_debian/tasks/main.yaml
+++ b/roles/docker_debian/tasks/main.yaml
@@ -41,6 +41,23 @@
   ansible.builtin.template:
     src: daemon.json.j2
     dest: /etc/docker/daemon.json
+# Debian's own docker packages conflict with the docker-ce stack at the
+# file level (docker-buildx ships /usr/libexec/docker/cli-plugins/docker-buildx,
+# which docker-buildx-plugin also owns), so apt's automatic removal aborts
+# mid-transaction and leaves dpkg broken with the daemon uninstalled.
+# Remove them explicitly before installing docker-ce.
+- name: Remove conflicting distro Docker packages
+  ansible.builtin.apt:
+    name:
+      - docker.io
+      - docker-cli
+      - docker-buildx
+      - docker-compose
+      - docker-doc
+      - podman-docker
+    state: absent
+  become: true
+  when: docker_debian_package == "docker-ce"
 - name: Install Docker
   ansible.builtin.apt:
     name: "{{ docker_debian_package }}"


### PR DESCRIPTION
## Summary

Any Debian host still running the distro's `docker.io` stack breaks when this role migrates it to `docker-ce`:

- `docker-buildx` (Debian) and `docker-buildx-plugin` (docker-ce) both ship `/usr/libexec/docker/cli-plugins/docker-buildx`
- apt removes `docker.io`/`containerd`/`runc` first, then dpkg aborts on the buildx file conflict
- Result: dpkg left half-configured, **no container runtime installed**, all containers on the host down until someone fixes it by hand

This hit `colo-docker-cache` twice on 2026-08-14 during the registry cache remediation (see internal-stack-iac #826 / #829) and will recur on every remaining `docker.io` host the next time its playbook runs.

## Change

Add a task that removes the Debian-native docker packages (`docker.io`, `docker-cli`, `docker-buildx`, `docker-compose`, `docker-doc`, `podman-docker` — per Docker's official install docs, plus the Debian 13 split packages) before the docker-ce install. Guarded on `docker_debian_package == "docker-ce"` so a host that deliberately overrides the package variable is untouched.

## Behaviour note

On a host being migrated, running containers stop when docker.io is removed and come back once docker-ce starts (containers with `restart_policy: always` restart automatically). That interruption already happened implicitly — this change just makes the migration complete instead of dying halfway.